### PR TITLE
DEVOPS-5410: Upgrade minitar to 0.6.1

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,8 @@
 ---
 driver:
   name: vagrant
+  customize:
+    audio: "none"
 
 provisioner:
   name: puppet_apply

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     metadata-json-lint (0.0.11)
       json
       spdx-licenses (~> 1.0)
-    minitar (0.5.4)
+    minitar (0.6.1)
     mixlib-install (1.1.0)
       artifactory
       mixlib-shellout


### PR DESCRIPTION
Also vagrant/vbox bug workaround added according to
https://github.com/test-kitchen/test-kitchen/issues/1383