### PR TITLE
DEVOPS-4498: ensure ams_security_version is not empty string

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,7 +10,7 @@ class syncope::install (
   $syncope_version            = $syncope::syncope_version,
   $syncope_console_version    = $syncope::syncope_console_version,
   $sts_version                = $syncope::sts_version,
-  $ams_security_version       = $syncope::ams_security_version
+  $ams_security_version       = pick($syncope::ams_security_version, 'latest')
 ){
 
   file {'/opt/tomcat':


### PR DESCRIPTION
Unfortunately retrieving value from facter returns empty string if not specified, but not undef.
Tested by local test run